### PR TITLE
Fix/do not bellow

### DIFF
--- a/include/GenericToolbox.Macro.h
+++ b/include/GenericToolbox.Macro.h
@@ -31,7 +31,7 @@
 #endif // HAS_CPP_11
 
 
-//#define WARN_DEPRECATED_FCT
+#define WARN_DEPRECATED_FCT /* Always flag deprecation */
 #ifndef WARN_DEPRECATED_FCT
 #define GT_DEPRECATED(msg_) // nothing
 #else

--- a/include/GenericToolbox.Utils.h
+++ b/include/GenericToolbox.Utils.h
@@ -427,7 +427,7 @@ namespace GenericToolbox{
     [[nodiscard]] bool isAboveMax(double val_) const{ return (hasUpperBound() and val_ > max); }
     [[nodiscard]] bool isInBounds(double val_) const{
       // both bounds are inclusive [min, max]
-      if( isBellowMin(val_) ){ return false; }
+      if( isBelowMin(val_) ){ return false; }
       if( isAboveMax(val_) ){ return false; }
       return true;
     }

--- a/include/GenericToolbox.Utils.h
+++ b/include/GenericToolbox.Utils.h
@@ -423,7 +423,7 @@ namespace GenericToolbox{
     [[nodiscard]] bool hasBothBounds() const{ return hasLowerBound() and hasUpperBound(); }
     [[nodiscard]] bool isUnbounded() const{ return not hasBound(); }
     [[nodiscard]] bool isBelowMin(double val_) const{ return (hasLowerBound() and val_ < min); }
-      [[nodiscard]] GT_DEPRECATED("Use isBelowMin") bool isBellowMin(double val_) const { return isBelowMin(val_); }
+    [[nodiscard]] GT_DEPRECATED("replace with isBelowMin()") bool isBellowMin(double val_) const { return isBelowMin(val_); }
     [[nodiscard]] bool isAboveMax(double val_) const{ return (hasUpperBound() and val_ > max); }
     [[nodiscard]] bool isInBounds(double val_) const{
       // both bounds are inclusive [min, max]

--- a/include/GenericToolbox.Utils.h
+++ b/include/GenericToolbox.Utils.h
@@ -422,7 +422,8 @@ namespace GenericToolbox{
     [[nodiscard]] bool hasBound() const{ return hasLowerBound() or hasUpperBound(); }
     [[nodiscard]] bool hasBothBounds() const{ return hasLowerBound() and hasUpperBound(); }
     [[nodiscard]] bool isUnbounded() const{ return not hasBound(); }
-    [[nodiscard]] bool isBellowMin(double val_) const{ return (hasLowerBound() and val_ < min); }
+    [[nodiscard]] bool isBelowMin(double val_) const{ return (hasLowerBound() and val_ < min); }
+      [[nodiscard]] GT_DEPRECATED("Use isBelowMin") bool isBellowMin(double val_) const { return isBelowMin(val_); }
     [[nodiscard]] bool isAboveMax(double val_) const{ return (hasUpperBound() and val_ > max); }
     [[nodiscard]] bool isInBounds(double val_) const{
       // both bounds are inclusive [min, max]


### PR DESCRIPTION
Fix a very interesting spelling mistake.  I don't think we want to bellow minimally.  This leaves the original spelling there as a deprecated routine, and adds the correct spelling as the main version.